### PR TITLE
ci(workflow): remove social media inputs from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,4 @@ jobs:
       extension-name: VSC-VsixManifestDesigner
       display-name: "VSIX Manifest Designer"
       marketplace-id: CodingWithCalvin.vsix-manifest-designer
-      description: "A visual designer for VS Code extension manifest files"
-      hashtags: "#vscode #extension #manifest #designer"
     secrets: inherit


### PR DESCRIPTION
## Summary
- Remove social media inputs (`description`, `hashtags`) from publish workflow that are no longer used by the reusable vsc-vsix-publish workflow

## Test plan
- [ ] Verify publish workflow still works correctly