### PR TITLE
docs(readme): remove retired VS Marketplace shields.io badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,6 @@
   </a>
 </p>
 
-<p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.vsix-manifest-designer">
-    <img src="https://img.shields.io/visual-studio-marketplace/v/CodingWithCalvin.vsix-manifest-designer?style=for-the-badge" alt="Marketplace Version">
-  </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.vsix-manifest-designer">
-    <img src="https://img.shields.io/visual-studio-marketplace/i/CodingWithCalvin.vsix-manifest-designer?style=for-the-badge" alt="Installs">
-  </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.vsix-manifest-designer">
-    <img src="https://img.shields.io/visual-studio-marketplace/d/CodingWithCalvin.vsix-manifest-designer?style=for-the-badge" alt="Downloads">
-  </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.vsix-manifest-designer">
-    <img src="https://img.shields.io/visual-studio-marketplace/r/CodingWithCalvin.vsix-manifest-designer?style=for-the-badge" alt="Rating">
-  </a>
-</p>
-
 ---
 
 ## 🤔 Why?


### PR DESCRIPTION
## Summary
- Removed retired shields.io Visual Studio Marketplace badges (Version, Installs, Downloads, Rating)
- The `visual-studio-marketplace` endpoint on shields.io has been retired and all badges show "Retired Badge"
- License and Build Status badges are unaffected and remain