### PR TITLE
ci(build): skip build on readme-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'webview-ui/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - '.github/workflows/build.yml'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add `paths` filter to `push` trigger so README-only commits (from the scheduled contributors workflow) no longer fire a build on main. Filter mirrors the existing `pull_request` paths.

## Test plan
- [ ] Confirm next scheduled contributors run does not trigger Build
- [ ] Confirm a `src/**` push still triggers Build
- [ ] Confirm PR sync still triggers Build